### PR TITLE
fix(chn): fix ":[0xFF]" bug

### DIFF
--- a/script/format/NpcsFormat.go
+++ b/script/format/NpcsFormat.go
@@ -168,7 +168,10 @@ func (f *Npcs) EncodeLine(str string) []byte {
 	hasName := false
 	tempStr := ""
 	for i < len(line) {
-		if line[i] == ':' && i+1 < len(line) && line[i+1] == '[' {
+		if line[i] == ':' && i+1 < len(line) && line[i+1] == '[' &&
+			// FIXME(kuriko): Special check for ":[0xFF]" (patch for chaos;head noah steam)
+			//   hopefully there is no one named `0xFF`.
+			!(i+6 < len(line) && strings.Contains(string(line[i+2:i+7]), "0xFF]")) {
 			inName = true
 			hasName = true
 			i += 2


### PR DESCRIPTION
fix ":[0xFF]" bug for Chaos;Head Noah(steam)/mes00/0003 (aka Tips)

For Chaos;Head Noah (steam) the 0003 file contains a special ":[0xFF]" string, which will cause the `NpcsFormat` decodeline run into wrong branch, treating 0xFF as a name.

>before fix
<img width="126" alt="图片" src="https://user-images.githubusercontent.com/31176859/197167649-52cc1212-3801-4804-9270-6ebeacd654f2.png">
the leading `0xFF` sequqnce appears in game
<img width="103" alt="图片" src="https://user-images.githubusercontent.com/31176859/197168068-6d3ac875-811d-44f3-9b18-98f28ec76ee7.png">

>after the fix
<img width="147" alt="图片" src="https://user-images.githubusercontent.com/31176859/197167710-57ce6142-da51-400d-8c2d-24350ef11560.png">


Maybe `NpcsPFormat` should also apply the same fix, but I have no time as well as little knowledge of golang to go through all code.
