### PR TITLE
fix(chn): 添加了更多的StringToken，修复了对Name标签的错误识别

### DIFF
--- a/script/format/NpcsFormat.go
+++ b/script/format/NpcsFormat.go
@@ -58,6 +58,12 @@ func (f *Npcs) DecodeLine(data []byte) string {
 		case PresentUnknown05:
 			text.WriteString(utils.FormatByte(data[i]))
 			i++
+		case PresentUnknown06:
+			text.WriteString(utils.FormatByte(data[i]))
+			i++
+		case TextWait:
+			text.WriteString(utils.FormatBytes(data[i : i+2]))
+			i += 2
 		case PresentResetAlignment:
 			text.WriteString(utils.FormatByte(data[i]))
 			i++
@@ -86,6 +92,9 @@ func (f *Npcs) DecodeLine(data []byte) string {
 			text.WriteString(utils.FormatBytes(data[i : i+3]))
 			i += 3
 		case GetHardcodedValue:
+			text.WriteString(utils.FormatBytes(data[i : i+3]))
+			i += 3
+		case PresentUnknown14:
 			text.WriteString(utils.FormatBytes(data[i : i+3]))
 			i += 3
 		case EvaluateExpression:
@@ -121,15 +130,21 @@ func (f *Npcs) DecodeLine(data []byte) string {
 			tmp.WriteByte(data[i])
 			text.WriteString(utils.FormatBytes(tmp.Bytes()))
 			i++
+		case PresentUnknown16:
+			text.WriteString(utils.FormatBytes(data[i : i+3]))
+			i += 3
 		case PresentUnknown18:
 			text.WriteString(utils.FormatByte(data[i]))
 			i++
 		case AutoForward:
-			text.WriteString(utils.FormatByte(data[i]))
-			i++
+			text.WriteString(utils.FormatBytes(data[i : i+3]))
+			i += 3
 		case AutoForward1A:
-			text.WriteString(utils.FormatByte(data[i]))
-			i++
+			text.WriteString(utils.FormatBytes(data[i : i+3]))
+			i += 3
+		case PresentUnknown1B:
+			text.WriteString(utils.FormatBytes(data[i : i+2]))
+			i += 2
 		case RubyCenterPerChar:
 			text.WriteString(utils.FormatByte(data[i]))
 			i++

--- a/script/format/NpcsPFormat.go
+++ b/script/format/NpcsPFormat.go
@@ -53,6 +53,12 @@ func (f *NpcsP) DecodeLine(data []byte) string {
 		case PresentUnknown05:
 			text.WriteString(utils.FormatByte(data[i]))
 			i++
+		case PresentUnknown06:
+			text.WriteString(utils.FormatByte(data[i]))
+			i++
+		case TextWait:
+			text.WriteString(utils.FormatBytes(data[i : i+2]))
+			i += 2
 		case PresentResetAlignment:
 			text.WriteString(utils.FormatByte(data[i]))
 			i++
@@ -81,6 +87,9 @@ func (f *NpcsP) DecodeLine(data []byte) string {
 			text.WriteString(utils.FormatBytes(data[i : i+3]))
 			i += 3
 		case GetHardcodedValue:
+			text.WriteString(utils.FormatBytes(data[i : i+3]))
+			i += 3
+		case PresentUnknown14:
 			text.WriteString(utils.FormatBytes(data[i : i+3]))
 			i += 3
 		case EvaluateExpression:
@@ -116,15 +125,21 @@ func (f *NpcsP) DecodeLine(data []byte) string {
 			tmp.WriteByte(data[i])
 			text.WriteString(utils.FormatBytes(tmp.Bytes()))
 			i++
+		case PresentUnknown16:
+			text.WriteString(utils.FormatBytes(data[i : i+3]))
+			i += 3
 		case PresentUnknown18:
 			text.WriteString(utils.FormatByte(data[i]))
 			i++
 		case AutoForward:
-			text.WriteString(utils.FormatByte(data[i]))
-			i++
+			text.WriteString(utils.FormatBytes(data[i : i+3]))
+			i += 3
 		case AutoForward1A:
-			text.WriteString(utils.FormatByte(data[i]))
-			i++
+			text.WriteString(utils.FormatBytes(data[i : i+3]))
+			i += 3
+		case PresentUnknown1B:
+			text.WriteString(utils.FormatBytes(data[i : i+2]))
+			i += 2
 		case RubyCenterPerChar:
 			text.WriteString(utils.FormatByte(data[i]))
 			i++

--- a/script/format/format.go
+++ b/script/format/format.go
@@ -7,6 +7,8 @@ const (
 	Present               = 0x03
 	SetColor              = 0x04
 	PresentUnknown05      = 0x05
+	PresentUnknown06      = 0x06
+	TextWait              = 0x07
 	PresentResetAlignment = 0x08
 	RubyBaseStart         = 0x09
 	RubyTextStart         = 0x0A
@@ -17,10 +19,13 @@ const (
 	SetMarginTop          = 0x11
 	SetMarginLeft         = 0x12
 	GetHardcodedValue     = 0x13
+	PresentUnknown14      = 0x14
 	EvaluateExpression    = 0x15
+	PresentUnknown16      = 0x16
 	PresentUnknown18      = 0x18
 	AutoForward           = 0x19
 	AutoForward1A         = 0x1A
+	PresentUnknown1B      = 0x1B
 	RubyCenterPerChar     = 0x1E
 	AltLineBreak          = 0x1F
 	Terminator            = 0xFF


### PR DESCRIPTION
错误来源：Chaos;Head Noah(steam) mes00脚本的0252, 0258等

以0252中的字符串为例(上方为对应的Hex，下方为导出的文本)，使用`NpcsFormat`格式：
```
01 8D A2 88 2E 02 11 00 E4 80 D8 80 E3 80 E3 86 A0 81 EC 82 00 81 E6 81 F8 80 EE 80 E3 80 E3 81 DE 81 E8 82 00 81 DE 82 04 80 D9 19 01 2C FF 
:[梨深[0x2CFF]]: [0x01][0x02][0x1100E4]「……殺さなくちゃ……いけないの」[0x19][0x01]
```
对于0x19操作码，其后的两个字节应为立即数，但逻辑中认为其没有立即数。所以当立即数高位字节为0x01时，程序误以为是NameStart，导致立即数低位字节0x2C和结束符0xFF被识别为一个Name，并且由于默认认为Name只有一个，导致`[0x2CFF]`和真实的Name组合在一起，导出时就会出现错误。
另外，若两个字节刚好在Charset的可能取值范围内（>=0x8000）。若存在对应字符，则会错误解析为字符，如下面的`96FF`被解析为“芬”：
```
8D C2 87 42 82 24 80 BE 86 54 82 FB 82 01 85 EB 81 E9 82 1E 81 13 81 13 19 00 96 FF 
両手を、左右に広げる――[0x19]#>芬
```
若不存在对应字符，则会报`Warning: 字库可能缺少 [%02X %02X] 对应的字符！`的警告。

StringToken的操作码和立即数信息参考了CoZ最近公开的MgsScriptTools工具的[stringtags配置文件](https://github.com/CommitteeOfZero/MgsScriptTools/blob/master/mgs-spec-bank/stringtags/base.yaml)。


